### PR TITLE
remove identifier from api

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ title str nr =
 
 view model =
   -- ...
-    Debug.View.inspect2 "title" title model.title model.version
+    Debug.View.inspect2 title model.title model.version
   -- ...
 ```

--- a/example/Main.elm
+++ b/example/Main.elm
@@ -49,9 +49,10 @@ view model =
             ]
         ]
         [ viewButton "-" Decrement
-        , Debug.View.inspect "counter" viewCounter model
+        , Debug.View.inspect viewCounter model
         , viewButton "+" Increment
-        , Debug.View.inspect "input" viewInput model.by
+        , Debug.View.inspect viewInput model.by
+        , Debug.View.inspect viewInput 0
         ]
 
 

--- a/src/Debug/View.elm
+++ b/src/Debug/View.elm
@@ -23,75 +23,79 @@ import Html.Keyed exposing (node)
 import Html.Attributes exposing (style, id, attribute, property, class)
 
 
-inspectBase : String -> Html msg -> (String -> List ElmType) -> Html msg
-inspectBase identifier view nativeFunction =
-    contentSpan
-        (view :: (wrapper identifier <| nativeFunction identifier))
+inspectBase : Html msg -> (String -> List ElmType) -> Html msg
+inspectBase view nativeFunction =
+    let
+        identifier =
+            Native.Debug.View.createId ()
+    in
+        contentSpan
+            (view :: (wrapper identifier <| nativeFunction identifier))
 
 
 {-| Inspect 1 value passed to a view-function.
 
     Debug.View.inspect "id" (\x -> h1 [] [ text x ]) model.title
 -}
-inspect : String -> (a -> Html msg) -> a -> Html msg
-inspect identifier view x1 =
-    inspectBase identifier (view x1) <|
+inspect : (a -> Html msg) -> a -> Html msg
+inspect view x1 =
+    inspectBase (view x1) <|
         Native.Debug.View.inspect x1
 
 
 {-| Inspect 2 value passed to a view-function.
 -}
-inspect2 : String -> (a -> b -> Html msg) -> a -> b -> Html msg
-inspect2 identifier view x1 x2 =
-    inspectBase identifier (view x1 x2) <|
+inspect2 : (a -> b -> Html msg) -> a -> b -> Html msg
+inspect2 view x1 x2 =
+    inspectBase (view x1 x2) <|
         Native.Debug.View.inspect2 x1 x2
 
 
 {-| Inspect 3 value passed to a view-function.
 -}
-inspect3 : String -> (a -> b -> c -> Html msg) -> a -> b -> c -> Html msg
-inspect3 identifier view x1 x2 x3 =
-    inspectBase identifier (view x1 x2 x3) <|
+inspect3 : (a -> b -> c -> Html msg) -> a -> b -> c -> Html msg
+inspect3 view x1 x2 x3 =
+    inspectBase (view x1 x2 x3) <|
         Native.Debug.View.inspect3 x1 x2 x3
 
 
 {-| Inspect 4 value passed to a view-function.
 -}
-inspect4 : String -> (a -> b -> c -> d -> Html msg) -> a -> b -> c -> d -> Html msg
-inspect4 identifier view x1 x2 x3 x4 =
-    inspectBase identifier (view x1 x2 x3 x4) <|
+inspect4 : (a -> b -> c -> d -> Html msg) -> a -> b -> c -> d -> Html msg
+inspect4 view x1 x2 x3 x4 =
+    inspectBase (view x1 x2 x3 x4) <|
         Native.Debug.View.inspect4 x1 x2 x3 x4
 
 
 {-| Inspect 5 value passed to a view-function.
 -}
-inspect5 : String -> (a -> b -> c -> d -> e -> Html msg) -> a -> b -> c -> d -> e -> Html msg
-inspect5 identifier view x1 x2 x3 x4 x5 =
-    inspectBase identifier (view x1 x2 x3 x4 x5) <|
+inspect5 : (a -> b -> c -> d -> e -> Html msg) -> a -> b -> c -> d -> e -> Html msg
+inspect5 view x1 x2 x3 x4 x5 =
+    inspectBase (view x1 x2 x3 x4 x5) <|
         Native.Debug.View.inspect5 x1 x2 x3 x4 x5
 
 
 {-| Inspect 6 value passed to a view-function.
 -}
-inspect6 : String -> (a -> b -> c -> d -> e -> f -> Html msg) -> a -> b -> c -> d -> e -> f -> Html msg
-inspect6 identifier view x1 x2 x3 x4 x5 x6 =
-    inspectBase identifier (view x1 x2 x3 x4 x5 x6) <|
+inspect6 : (a -> b -> c -> d -> e -> f -> Html msg) -> a -> b -> c -> d -> e -> f -> Html msg
+inspect6 view x1 x2 x3 x4 x5 x6 =
+    inspectBase (view x1 x2 x3 x4 x5 x6) <|
         Native.Debug.View.inspect6 x1 x2 x3 x4 x5 x6
 
 
 {-| Inspect 7 value passed to a view-function.
 -}
-inspect7 : String -> (a -> b -> c -> d -> e -> f -> g -> Html msg) -> a -> b -> c -> d -> e -> f -> g -> Html msg
-inspect7 identifier view x1 x2 x3 x4 x5 x6 x7 =
-    inspectBase identifier (view x1 x2 x3 x4 x5 x6 x7) <|
+inspect7 : (a -> b -> c -> d -> e -> f -> g -> Html msg) -> a -> b -> c -> d -> e -> f -> g -> Html msg
+inspect7 view x1 x2 x3 x4 x5 x6 x7 =
+    inspectBase (view x1 x2 x3 x4 x5 x6 x7) <|
         Native.Debug.View.inspect7 x1 x2 x3 x4 x5 x6 x7
 
 
 {-| Inspect 8 value passed to a view-function.
 -}
-inspect8 : String -> (a -> b -> c -> d -> e -> f -> g -> h -> Html msg) -> a -> b -> c -> d -> e -> f -> g -> h -> Html msg
-inspect8 identifier view x1 x2 x3 x4 x5 x6 x7 x8 =
-    inspectBase identifier (view x1 x2 x3 x4 x5 x6 x7 x8) <|
+inspect8 : (a -> b -> c -> d -> e -> f -> g -> h -> Html msg) -> a -> b -> c -> d -> e -> f -> g -> h -> Html msg
+inspect8 view x1 x2 x3 x4 x5 x6 x7 x8 =
+    inspectBase (view x1 x2 x3 x4 x5 x6 x7 x8) <|
         Native.Debug.View.inspect8 x1 x2 x3 x4 x5 x6 x7 x8
 
 

--- a/src/Native/Debug/View.js
+++ b/src/Native/Debug/View.js
@@ -2,6 +2,15 @@
 var _stoeffel$debug_view$Native_Debug_View = (function() {
   var log = {};
   var clickHandlers = {};
+  function createId() {
+    var id = "";
+    try {
+      throw Error();
+    } catch (e) {
+      id = e.stack + "";
+    }
+    return id;
+  }
   function inspect(a, id) {
     if (!log[id]) {
       log[id] = [];
@@ -66,7 +75,8 @@ var _stoeffel$debug_view$Native_Debug_View = (function() {
     inspect5: F6(inspect5),
     inspect6: F7(inspect6),
     inspect7: F8(inspect7),
-    inspect8: F9(inspect8)
+    inspect8: F9(inspect8),
+    createId: createId
   };
 
   // This is a modified version of toString from elm core: https://github.com/elm-lang/core/blob/3.0.0/src/Native/Utils.js#L358


### PR DESCRIPTION
This drops the identifier from `inspect`. 
This way we can write:

```diff
- Debug.View.inspect2 "title" model.title model.version
+ Debug.View.inspect2 model.title model.version
```

Thanks for the idea @joneshf ❤️ 